### PR TITLE
fix superstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,13 @@
         "cheerio": "^1.0.0-rc.12",
         "crypto-js": "^4.1.1",
         "form-data": "^4.0.0",
-        "nanoid": "^5.0.1",
-        "node-fetch": "^2.7.0"
+        "node-fetch": "^2.7.0",
+        "randombytes": "^2.1.0"
       },
       "devDependencies": {
         "@types/crypto-js": "^4.1.1",
         "@types/node-fetch": "^2.6.6",
+        "@types/randombytes": "^2.0.1",
         "@types/spinnies": "^0.5.1",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
@@ -940,6 +941,15 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/randombytes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.1.tgz",
+      "integrity": "sha512-kWMqPyxpTUTofwbGN47MWddBFiJnWJlfLBdDg2NvmZSKHOmKY9ujVA3PIfBgXcIHTCpsqoQqYudBwanFXzGD9A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -3501,9 +3511,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -4698,23 +4708,6 @@
         "url": "https://github.com/sponsors/raouldeheer"
       }
     },
-    "node_modules/nanoid": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.1.tgz",
-      "integrity": "sha512-vWeVtV5Cw68aML/QaZvqN/3QQXc6fBfIieAlu05m7FZW2Dgb+3f0xc0TTxuJW+7u30t7iSDTV/j3kVI0oJqIfQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5258,6 +5251,14 @@
         }
       ]
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -5427,6 +5428,25 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@types/crypto-js": "^4.1.1",
     "@types/node-fetch": "^2.6.6",
+    "@types/randombytes": "^2.0.1",
     "@types/spinnies": "^0.5.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
@@ -76,7 +77,7 @@
     "cheerio": "^1.0.0-rc.12",
     "crypto-js": "^4.1.1",
     "form-data": "^4.0.0",
-    "nanoid": "^5.0.1",
-    "node-fetch": "^2.7.0"
+    "node-fetch": "^2.7.0",
+    "randombytes": "^2.1.0"
   }
 }

--- a/src/providers/sources/superstream/sendRequest.ts
+++ b/src/providers/sources/superstream/sendRequest.ts
@@ -1,12 +1,11 @@
 import CryptoJS from 'crypto-js';
-import { customAlphabet } from 'nanoid';
+import randomBytes from 'randombytes';
 
 import type { ScrapeContext } from '@/utils/context';
 
 import { apiUrls, appId, appKey, key } from './common';
 import { encrypt, getVerify } from './crypto';
 
-const nanoid = customAlphabet('0123456789abcdef', 32);
 const expiry = () => Math.floor(Date.now() / 1000 + 60 * 60 * 12);
 
 export const sendRequest = async (ctx: ScrapeContext, data: object, altApi = false) => {
@@ -40,7 +39,7 @@ export const sendRequest = async (ctx: ScrapeContext, data: object, altApi = fal
   formatted.append('platform', 'android');
   formatted.append('version', '129');
   formatted.append('medium', 'Website');
-  formatted.append('token', nanoid());
+  formatted.append('token', randomBytes(16).toString('hex'));
 
   const requestUrl = altApi ? apiUrls[1] : apiUrls[0];
 


### PR DESCRIPTION
This pull request resolves #8 

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.

#8 was caused due to the `nanoid` module not supporting CommonJS. The usage for `nanoid` in this case was just to generate a random 32 character hex string, which can easily be done in several other ways without needing `nanoid`

https://github.com/browserify/randombytes is now used to generate the hex string. It uses `crypto.randomBytes` when on the server and `crypto/msCrypto.getRandomValues` in the browser

Tested on a couple movies using the new test script and it works just fine