### PR TITLE
Add disabled embed filter to scrapeInvidualSource and runAllProviders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@movie-web/providers",
-  "version": "1.1.5",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@movie-web/providers",
-      "version": "1.1.5",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",

--- a/src/runners/individualRunner.ts
+++ b/src/runners/individualRunner.ts
@@ -58,6 +58,14 @@ export async function scrapeInvidualSource(
   }
 
   if (!output) throw new Error('output is null');
+
+  // filter output with only valid embeds that are not disabled
+  output.embeds = output.embeds.filter((embed) => {
+    const e = list.embeds.find((v) => v.id === embed.embedId);
+    if (!e || e.disabled) return false;
+    return true;
+  });
+
   if ((!output.stream || output.stream.length === 0) && output.embeds.length === 0)
     throw new NotFoundError('No streams found');
   return output;

--- a/src/runners/runner.ts
+++ b/src/runners/runner.ts
@@ -116,8 +116,14 @@ export async function runAllProviders(list: ProviderList, ops: ProviderRunnerOpt
       };
     }
 
-    // run embed scrapers on listed embeds
-    const sortedEmbeds = output.embeds.sort((a, b) => embedIds.indexOf(a.embedId) - embedIds.indexOf(b.embedId));
+    // filter disabled and run embed scrapers on listed embeds
+    const sortedEmbeds = output.embeds
+      .filter((embed) => {
+        const e = list.embeds.find((v) => v.id === embed.embedId);
+        if (!e || e.disabled) return false;
+        return true;
+      })
+      .sort((a, b) => embedIds.indexOf(a.embedId) - embedIds.indexOf(b.embedId));
 
     if (sortedEmbeds.length > 0) {
       ops.events?.discoverEmbeds?.({


### PR DESCRIPTION
This pull request resolves movie-web/movie-web#720

Result:
VidSrc no longer shows an "Unknown option", now there is no extra embed select since there is only one option
![image](https://github.com/movie-web/providers/assets/43169049/f534f552-a21a-4a59-a690-329020f0ca65)
![image](https://github.com/movie-web/providers/assets/43169049/449afd11-0559-47bc-b47d-896307513597)


 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
