### PR TITLE
VidSrc: Remove equal signs inside base64 encoded string

### DIFF
--- a/src/providers/embeds/vidsrc.ts
+++ b/src/providers/embeds/vidsrc.ts
@@ -15,11 +15,7 @@ export const vidsrcembedScraper = makeEmbed({
       },
     });
 
-    const match = html
-      .match(hlsURLRegex)?.[1]
-      ?.replace(/(\/\/\S+?=)/g, '')
-      .replace('#2', '')
-      .replace(/=/g, '');
+    const match = html.match(hlsURLRegex)?.[1]?.replace(/(\/\/\S+?=)|#2|=/g, '');
     if (!match) throw new Error('Unable to find HLS playlist');
     const finalUrl = atob(match);
 

--- a/src/providers/embeds/vidsrc.ts
+++ b/src/providers/embeds/vidsrc.ts
@@ -18,7 +18,8 @@ export const vidsrcembedScraper = makeEmbed({
     const match = html
       .match(hlsURLRegex)?.[1]
       ?.replace(/(\/\/\S+?=)/g, '')
-      .replace('#2', '');
+      .replace('#2', '')
+      .replace(/=/g, '');
     if (!match) throw new Error('Unable to find HLS playlist');
     const finalUrl = atob(match);
 


### PR DESCRIPTION
- Fixes VidSrc failing to decode and retrieve the source URL.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
