### PR TITLE
replace vidplay decryption keys and domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@movie-web/providers",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@movie-web/providers",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",

--- a/src/providers/embeds/vidplay/common.ts
+++ b/src/providers/embeds/vidplay/common.ts
@@ -2,16 +2,14 @@ import { makeFullUrl } from '@/fetchers/common';
 import { decodeData } from '@/providers/sources/vidsrcto/common';
 import { EmbedScrapeContext } from '@/utils/context';
 
-export const vidplayBase = 'https://vidplay.site';
-export const referer = 'https://vidplay.online/';
+export const vidplayBase = 'https://vidplay.online';
+export const referer = `${vidplayBase}/`;
 
 // This file is based on https://github.com/Ciarands/vidsrc-to-resolver/blob/dffa45e726a4b944cb9af0c9e7630476c93c0213/vidsrc.py#L16
 // Full credits to @Ciarands!
 
 export const getDecryptionKeys = async (ctx: EmbedScrapeContext): Promise<string[]> => {
-  const res = await ctx.fetcher<string>(
-    'https://raw.githubusercontent.com/Claudemirovsky/worstsource-keys/keys/keys.json',
-  );
+  const res = await ctx.fetcher<string>('https://raw.githubusercontent.com/Ciarands/vidsrc-keys/main/keys.json');
   return JSON.parse(res);
 };
 


### PR DESCRIPTION
- Replaced the decryption keys for Vidplay.
- Also switched domain, since the current one is timing out.
- Massive thanks to @Ciarands!

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
