### PR TITLE
Fix vidsrc.me url decoding

### DIFF
--- a/src/providers/embeds/vidsrc.ts
+++ b/src/providers/embeds/vidsrc.ts
@@ -4,6 +4,14 @@ import { makeEmbed } from '@/providers/base';
 const hlsURLRegex = /file:"(.*?)"/;
 const setPassRegex = /var pass_path = "(.*set_pass\.php.*)";/;
 
+function formatHlsB64(data: string): string {
+  const encodedB64 = data.replace(/\/@#@\/[^=/]+==/g, '');
+  if (encodedB64.match(/\/@#@\/[^=/]+==/)) {
+    return formatHlsB64(encodedB64);
+  }
+  return encodedB64;
+}
+
 export const vidsrcembedScraper = makeEmbed({
   id: 'vidsrcembed', // VidSrc is both a source and an embed host
   name: 'VidSrc',
@@ -15,10 +23,12 @@ export const vidsrcembedScraper = makeEmbed({
       },
     });
 
-    const match = html.match(hlsURLRegex)?.[1]?.replace(/(\/\/\S+?=)|#2|=/g, '');
-    if (!match) throw new Error('Unable to find HLS playlist');
-    const finalUrl = atob(match);
-
+    // When this eventually breaks see the player js @ pjs_main.js
+    // If you know what youre doing and are slightly confused about how to reverse this feel free to reach out to ciaran_ds on discord with any queries
+    let hlsMatch = html.match(hlsURLRegex)?.[1]?.slice(2);
+    if (!hlsMatch) throw new Error('Unable to find HLS playlist');
+    hlsMatch = formatHlsB64(hlsMatch);
+    const finalUrl = atob(hlsMatch);
     if (!finalUrl.includes('.m3u8')) throw new Error('Unable to find HLS playlist');
 
     let setPassLink = html.match(setPassRegex)?.[1];


### PR DESCRIPTION
This PR fixes vidsrc.me hls url decoding by recursively removing bad data in the b64.

This pull request resolves #XXX

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
