### PR TITLE
Fixed VidSrcTo crashing if no subtitles are found

### DIFF
--- a/src/providers/sources/vidsrcto/index.ts
+++ b/src/providers/sources/vidsrcto/index.ts
@@ -46,7 +46,10 @@ const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Pr
   }
 
   // Originally Filemoon does not have subtitles. But we can use the ones from Vidplay.
-  const subtitleUrl = new URL(embedUrls.find((v) => v.includes('sub.info')) ?? '').searchParams.get('sub.info');
+  const urlWithSubtitles = embedUrls.find((v) => v.includes('sub.info'));
+  let subtitleUrl: string | null = null;
+  if (urlWithSubtitles) subtitleUrl = new URL(urlWithSubtitles).searchParams.get('sub.info');
+
   for (const source of sources.result) {
     if (source.title === 'Vidplay') {
       const embedUrl = embedUrls.find((v) => v.includes('vidplay'));


### PR DESCRIPTION
- Example show that is not working: https://movie-web.app/media/tmdb-tv-332-los-simuladores/978/17106
- Tested the code for both movies and shows with and without subtitles

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
