### PR TITLE
Fix missing captions from UpCloud/VidCloud embeds

### DIFF
--- a/src/providers/embeds/upcloud.ts
+++ b/src/providers/embeds/upcloud.ts
@@ -110,7 +110,7 @@ export const upcloudScraper = makeEmbed({
       if (track.kind !== 'captions') return;
       const type = getCaptionTypeFromUrl(track.file);
       if (!type) return;
-      const language = labelToLanguageCode(track.label);
+      const language = labelToLanguageCode(track.label.split(' ')[0]);
       if (!language) return;
       captions.push({
         id: track.file,


### PR DESCRIPTION
For some streams, the caption labels of the UpCloud/VidCloud embeds include a suffix of the language in its native tongue (e.g. Dutch - Nederlands). This made the language code lookup fail and therefor no captions were returned by the scraper. This PR fixes this by only taking the first part of the label.

This pull request resolves #XXX

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
