### PR TITLE
Fix Vidplay cached keys

### DIFF
--- a/src/providers/embeds/vidplay/common.ts
+++ b/src/providers/embeds/vidplay/common.ts
@@ -9,8 +9,12 @@ export const referer = `${vidplayBase}/`;
 // Full credits to @Ciarands!
 
 export const getDecryptionKeys = async (ctx: EmbedScrapeContext): Promise<string[]> => {
-  const res = await ctx.fetcher<string>('https://raw.githubusercontent.com/Ciarands/vidsrc-keys/main/keys.json');
-  return JSON.parse(res);
+  const res = await ctx.fetcher<string>('https://github.com/Ciarands/vidsrc-keys/blob/main/keys.json');
+  const regex = /"rawLines":\s*\[([\s\S]*?)\]/;
+  const rawLines = res.match(regex)?.[1];
+  if (!rawLines) throw new Error('No keys found');
+  const keys = JSON.parse(`${rawLines.substring(1).replace(/\\"/g, '"')}]`);
+  return keys;
 };
 
 export const getEncodedId = async (ctx: EmbedScrapeContext) => {

--- a/src/providers/embeds/vidplay/common.ts
+++ b/src/providers/embeds/vidplay/common.ts
@@ -9,7 +9,7 @@ export const referer = `${vidplayBase}/`;
 // Full credits to @Ciarands!
 
 export const getDecryptionKeys = async (ctx: EmbedScrapeContext): Promise<string[]> => {
-  const res = await ctx.fetcher<string>('https://github.com/Ciarands/vidsrc-keys/blob/main/keys.json');
+  const res = await ctx.proxiedFetcher<string>('https://github.com/Ciarands/vidsrc-keys/blob/main/keys.json');
   const regex = /"rawLines":\s*\[([\s\S]*?)\]/;
   const rawLines = res.match(regex)?.[1];
   if (!rawLines) throw new Error('No keys found');


### PR DESCRIPTION
- Raw GitHub domain caches each page for 5 minutes each hour. This results in the keys being outdated for the first 5 minutes each hour.
- Instead we scrape GitHub itself, to get the up-to-date keys.
- For some reason it was failing in the browser CLI test, but it seems to work in a local instance of movie-web with the update.
![image](https://github.com/movie-web/providers/assets/43169049/bf93ef4b-5cca-46ae-a48c-ed2dc119de89)
![image](https://github.com/movie-web/providers/assets/43169049/172f2339-9b6b-403c-9b13-8cfda9dffa3d)

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
