### PR TITLE
Add thumbnail track option to response

### DIFF
--- a/src/providers/streams.ts
+++ b/src/providers/streams.ts
@@ -8,10 +8,16 @@ export type StreamFile = {
 
 export type Qualities = 'unknown' | '360' | '480' | '720' | '1080' | '4k';
 
+type ThumbnailTrack = {
+  type: 'vtt';
+  url: string;
+};
+
 type StreamCommon = {
   id: string; // only unique per output
   flags: Flags[];
   captions: Caption[];
+  thumbnailTrack?: ThumbnailTrack;
   headers?: Record<string, string>; // these headers HAVE to be set to watch the stream
   preferredHeaders?: Record<string, string>; // these headers are optional, would improve the stream
 };


### PR DESCRIPTION
changes:
 - add option to return a thumbnail track. But not providers that support it yet.
