### PR TITLE
Fix closeload scraper

### DIFF
--- a/src/providers/embeds/closeload.ts
+++ b/src/providers/embeds/closeload.ts
@@ -43,7 +43,7 @@ export const closeLoadScraper = makeEmbed({
     const evalCode = iframeRes$('script')
       .filter((_, el) => {
         const script = iframeRes$(el);
-        return (script.attr('type') === 'text/javascript' && script.html()?.includes('eval')) ?? false;
+        return (script.attr('type') === 'text/javascript' && script.html()?.includes('p,a,c,k,e,d')) ?? false;
       })
       .html();
     if (!evalCode) throw new Error("Couldn't find eval code");


### PR DESCRIPTION
The scraper was selecting the wrong script on the HTML page. Note that this source still wont work on the site, because of movie-web/movie-web#905

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
