### PR TITLE
fix ridomovies not working for some shows and movies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@movie-web/providers",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@movie-web/providers",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",

--- a/src/providers/sources/ridomovies/index.ts
+++ b/src/providers/sources/ridomovies/index.ts
@@ -28,9 +28,9 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
     const showPageResult = await ctx.proxiedFetcher<string>(`/${show.fullSlug}`, {
       baseUrl: ridoMoviesBase,
     });
-    const fullEpisodeSlug = `${show.fullSlug}/season-${ctx.media.season.number}/episode-${ctx.media.episode.number}`;
+    const fullEpisodeSlug = `season-${ctx.media.season.number}/episode-${ctx.media.episode.number}`;
     const regexPattern = new RegExp(
-      `\\\\"id\\\\":\\\\"(\\d+)\\\\"(?=.*?\\\\\\"fullSlug\\\\\\":\\\\\\"${fullEpisodeSlug}\\\\\\")`,
+      `\\\\"id\\\\":\\\\"(\\d+)\\\\"(?=.*?\\\\\\"fullSlug\\\\\\":\\\\\\"[^"]*${fullEpisodeSlug}[^"]*\\\\\\")`,
       'g',
     );
     const matches = [...showPageResult.matchAll(regexPattern)];


### PR DESCRIPTION
This pull request resolves ridomovies not working for some shows and movies because of differences in slugs between search result and player page. We now only check for season and episode number

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
