### PR TITLE
Fix URLSearchParams usage for react-native

### DIFF
--- a/src/fetchers/body.ts
+++ b/src/fetchers/body.ts
@@ -12,7 +12,9 @@ export function serializeBody(body: FetcherOptions['body']): SeralizedBody {
   if (body === undefined || typeof body === 'string' || body instanceof URLSearchParams || body instanceof FormData) {
     if (body instanceof URLSearchParams && isReactNative()) {
       return {
-        headers: {},
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
         body: body.toString(),
       };
     }

--- a/src/fetchers/body.ts
+++ b/src/fetchers/body.ts
@@ -1,6 +1,7 @@
 import FormData from 'form-data';
 
 import { FetcherOptions } from '@/fetchers/types';
+import { isReactNative } from '@/utils/native';
 
 export interface SeralizedBody {
   headers: Record<string, string>;
@@ -8,11 +9,18 @@ export interface SeralizedBody {
 }
 
 export function serializeBody(body: FetcherOptions['body']): SeralizedBody {
-  if (body === undefined || typeof body === 'string' || body instanceof URLSearchParams || body instanceof FormData)
+  if (body === undefined || typeof body === 'string' || body instanceof URLSearchParams || body instanceof FormData) {
+    if (body instanceof URLSearchParams && isReactNative()) {
+      return {
+        headers: {},
+        body: body.toString(),
+      };
+    }
     return {
       headers: {},
       body,
     };
+  }
 
   // serialize as JSON
   return {

--- a/src/providers/sources/showbox/sendRequest.ts
+++ b/src/providers/sources/showbox/sendRequest.ts
@@ -2,7 +2,6 @@ import CryptoJS from 'crypto-js';
 import { customAlphabet } from 'nanoid';
 
 import type { ScrapeContext } from '@/utils/context';
-import { createSearchParams } from '@/utils/params';
 
 import { apiUrls, appId, appKey, key } from './common';
 import { encrypt, getVerify } from './crypto';
@@ -35,14 +34,13 @@ export const sendRequest = async (ctx: ScrapeContext, data: object, altApi = fal
   });
   const base64body = btoa(body);
 
-  const formatted = {
-    data: base64body,
-    appid: '27',
-    platform: 'android',
-    version: '129',
-    medium: 'Website',
-    token: randomId(32),
-  };
+  const formatted = new URLSearchParams();
+  formatted.append('data', base64body);
+  formatted.append('appid', '27');
+  formatted.append('platform', 'android');
+  formatted.append('version', '129');
+  formatted.append('medium', 'Website');
+  formatted.append('token', randomId(32));
 
   const requestUrl = altApi ? apiUrls[1] : apiUrls[0];
 
@@ -53,7 +51,7 @@ export const sendRequest = async (ctx: ScrapeContext, data: object, altApi = fal
       'Content-Type': 'application/x-www-form-urlencoded',
       'User-Agent': 'okhttp/3.2.0',
     },
-    body: createSearchParams(formatted),
+    body: formatted,
   });
   return JSON.parse(response);
 };

--- a/src/utils/native.ts
+++ b/src/utils/native.ts
@@ -1,0 +1,9 @@
+export const isReactNative = () => {
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    require('react-native');
+    return true;
+  } catch (e) {
+    return false;
+  }
+};

--- a/src/utils/params.ts
+++ b/src/utils/params.ts
@@ -1,5 +1,0 @@
-export function createSearchParams(params: { [key: string]: string | number }): string {
-  return Object.entries(params)
-    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-    .join('&');
-}


### PR DESCRIPTION
This allows users to still use URLSearchParams like they are used to, but have it work in react-native. This way contributors do not have to know that they are required to use a different function for creating URLSearchParams. 

react-native partially implements URLSearchParams (constructor and .append()), but does not support a class instance of URLSearchParams to be passed into the native fetch call. If we stringify the class, we achieve the desired result in react-native.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
