### PR TITLE
VidSrc streams no longer worker without Referer header set.

### DIFF
--- a/src/providers/embeds/vidsrc.ts
+++ b/src/providers/embeds/vidsrc.ts
@@ -54,6 +54,10 @@ export const vidsrcembedScraper = makeEmbed({
           type: 'hls',
           playlist: finalUrl,
           flags: [flags.CORS_ALLOWED],
+          // VidSrc streams now require a referer header, if not set the streams return 403.
+          headers: {
+            referer: ctx.url,
+          },
           captions: [],
         },
       ],

--- a/src/providers/sources/vidsrc/index.ts
+++ b/src/providers/sources/vidsrc/index.ts
@@ -7,7 +7,8 @@ export const vidsrcScraper = makeSourcerer({
   id: 'vidsrc',
   name: 'VidSrc',
   rank: 120,
-  flags: [flags.CORS_ALLOWED],
+  // No longer works without refrer header
+  flags: [],
   scrapeMovie,
   scrapeShow,
 });


### PR DESCRIPTION
I've removed the flag CORS_ALLOWED and made referer a required header.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [ ] I have tested all of my changes.
