### PR TITLE
Updated compare function to check a edge case

### DIFF
--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -1,12 +1,12 @@
 import { CommonMedia } from '@/entrypoint/utils/media';
 
 export function normalizeTitle(title: string): string {
-  let titleTrimmed = title.trim();
-  if (titleTrimmed !== "The Movie" && titleTrimmed.endsWith("The Movie")) {
-    titleTrimmed = titleTrimmed.replace("The Movie", "");
+  let titleTrimmed = title.trim().toLowerCase();
+  if (((titleTrimmed !== "the movie" && titleTrimmed.endsWith("the movie")) || 
+    (titleTrimmed !== "the series" && titleTrimmed.endsWith("the series")))) {
+    titleTrimmed = titleTrimmed.replace("the movie", "");
   }
   return titleTrimmed
-    .toLowerCase()
     .replace(/['":]/g, "")
     .replace(/[^a-zA-Z0-9]+/g, "_");
 }

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -2,9 +2,11 @@ import { CommonMedia } from '@/entrypoint/utils/media';
 
 export function normalizeTitle(title: string): string {
   let titleTrimmed = title.trim().toLowerCase();
-  if (((titleTrimmed !== "the movie" && titleTrimmed.endsWith("the movie")) || 
-    (titleTrimmed !== "the series" && titleTrimmed.endsWith("the series")))) {
+  if (((titleTrimmed !== "the movie" && titleTrimmed.endsWith("the movie")))) {
     titleTrimmed = titleTrimmed.replace("the movie", "");
+  }
+  if (((titleTrimmed !== "the series" && titleTrimmed.endsWith("the series")))) {
+    titleTrimmed = titleTrimmed.replace("the series", "");
   }
   return titleTrimmed
     .replace(/['":]/g, "")

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -2,15 +2,13 @@ import { CommonMedia } from '@/entrypoint/utils/media';
 
 export function normalizeTitle(title: string): string {
   let titleTrimmed = title.trim().toLowerCase();
-  if (((titleTrimmed !== "the movie" && titleTrimmed.endsWith("the movie")))) {
-    titleTrimmed = titleTrimmed.replace("the movie", "");
+  if (titleTrimmed !== 'the movie' && titleTrimmed.endsWith('the movie')) {
+    titleTrimmed = titleTrimmed.replace('the movie', '');
   }
-  if (((titleTrimmed !== "the series" && titleTrimmed.endsWith("the series")))) {
-    titleTrimmed = titleTrimmed.replace("the series", "");
+  if (titleTrimmed !== 'the series' && titleTrimmed.endsWith('the series')) {
+    titleTrimmed = titleTrimmed.replace('the series', '');
   }
-  return titleTrimmed
-    .replace(/['":]/g, "")
-    .replace(/[^a-zA-Z0-9]+/g, "_");
+  return titleTrimmed.replace(/['":]/g, '').replace(/[^a-zA-Z0-9]+/g, '_');
 }
 
 export function compareTitle(a: string, b: string): boolean {

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -1,11 +1,14 @@
 import { CommonMedia } from '@/entrypoint/utils/media';
 
 export function normalizeTitle(title: string): string {
-  return title
-    .trim()
+  let titleTrimmed = title.trim();
+  if (titleTrimmed !== "The Movie" && titleTrimmed.endsWith("The Movie")) {
+    titleTrimmed = titleTrimmed.replace("The Movie", "");
+  }
+  return titleTrimmed
     .toLowerCase()
-    .replace(/['":]/g, '')
-    .replace(/[^a-zA-Z0-9]+/g, '_');
+    .replace(/['":]/g, "")
+    .replace(/[^a-zA-Z0-9]+/g, "_");
 }
 
 export function compareTitle(a: string, b: string): boolean {


### PR DESCRIPTION
This pull request resolves #227
- Updated the normalizeTitle function to cover an edge case where the title contains the "The Movie"

 - [ ] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [ ] I have tested all of my changes.
- [ ] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
