### PR TITLE
Fix embedUrl matching for Vidplay and Filemoon sources

### DIFF
--- a/src/providers/embeds/filemoon/index.ts
+++ b/src/providers/embeds/filemoon/index.ts
@@ -1,7 +1,8 @@
 import { unpack } from 'unpacker';
 
+import { flags } from '@/entrypoint/utils/targets';
+
 import { SubtitleResult } from './types';
-import { flags } from '../../../../lib';
 import { makeEmbed } from '../../base';
 import { Caption, getCaptionTypeFromUrl, labelToLanguageCode } from '../../captions';
 

--- a/src/providers/embeds/filemoon/index.ts
+++ b/src/providers/embeds/filemoon/index.ts
@@ -1,6 +1,7 @@
 import { unpack } from 'unpacker';
 
 import { SubtitleResult } from './types';
+import { flags } from '../../../../lib';
 import { makeEmbed } from '../../base';
 import { Caption, getCaptionTypeFromUrl, labelToLanguageCode } from '../../captions';
 
@@ -49,7 +50,7 @@ export const fileMoonScraper = makeEmbed({
           id: 'primary',
           type: 'hls',
           playlist: file[1],
-          flags: [],
+          flags: [flags.CORS_ALLOWED],
           captions,
         },
       ],

--- a/src/providers/embeds/vidplay/index.ts
+++ b/src/providers/embeds/vidplay/index.ts
@@ -1,7 +1,8 @@
+import { flags } from '@/entrypoint/utils/targets';
 import { makeEmbed } from '@/providers/base';
 import { Caption, getCaptionTypeFromUrl, labelToLanguageCode } from '@/providers/captions';
 
-import { getFileUrl, referer } from './common';
+import { getFileUrl } from './common';
 import { SubtitleResult, VidplaySourceResponse } from './types';
 
 export const vidplayScraper = makeEmbed({
@@ -44,12 +45,8 @@ export const vidplayScraper = makeEmbed({
           id: 'primary',
           type: 'hls',
           playlist: source,
-          flags: [],
+          flags: [flags.CORS_ALLOWED],
           captions,
-          preferredHeaders: {
-            Referer: referer,
-            Origin: referer,
-          },
         },
       ],
     };

--- a/src/providers/sources/vidsrcto/index.ts
+++ b/src/providers/sources/vidsrcto/index.ts
@@ -45,15 +45,9 @@ const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Pr
     embedArr.push({ source: source.title, url: decryptedUrl });
   }
 
-  // Originally Filemoon does not have subtitles. But we can use the ones from Vidplay.
-  const urlWithSubtitles = embedArr.find((v) => v.url.includes('sub.info'))?.url;
-  let subtitleUrl: string | null = null;
-  if (urlWithSubtitles) subtitleUrl = new URL(urlWithSubtitles).searchParams.get('sub.info');
-
   for (const embedObj of embedArr) {
     if (embedObj.source === 'Vidplay') {
       const fullUrl = new URL(embedObj.url);
-      if (subtitleUrl) fullUrl.searchParams.set('sub.info', subtitleUrl);
       embeds.push({
         embedId: 'vidplay',
         url: fullUrl.toString(),
@@ -62,6 +56,9 @@ const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Pr
 
     if (embedObj.source === 'Filemoon') {
       const fullUrl = new URL(embedObj.url);
+      // Originally Filemoon does not have subtitles. But we can use the ones from Vidplay.
+      const urlWithSubtitles = embedArr.find((v) => v.source === 'Vidplay' && v.url.includes('sub.info'))?.url;
+      const subtitleUrl = urlWithSubtitles ? new URL(urlWithSubtitles).searchParams.get('sub.info') : null;
       if (subtitleUrl) fullUrl.searchParams.set('sub.info', subtitleUrl);
       embeds.push({
         embedId: 'filemoon',

--- a/src/providers/sources/vidsrcto/index.ts
+++ b/src/providers/sources/vidsrcto/index.ts
@@ -52,7 +52,7 @@ const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Pr
 
   for (const source of sources.result) {
     if (source.title === 'Vidplay') {
-      const embedUrl = embedUrls.find((v) => v.includes('vidplay'));
+      const embedUrl = embedUrls.find((v) => v.match(/https:\/\/(?:[a-zA-Z0-9]{10})\./));
       if (!embedUrl) continue;
       embeds.push({
         embedId: 'vidplay',
@@ -61,7 +61,7 @@ const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Pr
     }
 
     if (source.title === 'Filemoon') {
-      const embedUrl = embedUrls.find((v) => v.includes('filemoon'));
+      const embedUrl = embedUrls.find((v) => v.includes('kerapoxy'));
       if (!embedUrl) continue;
       const fullUrl = new URL(embedUrl);
       if (subtitleUrl) fullUrl.searchParams.set('sub.info', subtitleUrl);

--- a/src/providers/sources/vidsrcto/index.ts
+++ b/src/providers/sources/vidsrcto/index.ts
@@ -1,5 +1,6 @@
 import { load } from 'cheerio';
 
+import { flags } from '@/entrypoint/utils/targets';
 import { SourcererEmbed, SourcererOutput, makeSourcerer } from '@/providers/base';
 import { MovieScrapeContext, ShowScrapeContext } from '@/utils/context';
 
@@ -77,6 +78,6 @@ export const vidSrcToScraper = makeSourcerer({
   name: 'VidSrcTo',
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,
-  flags: [],
+  flags: [flags.CORS_ALLOWED],
   rank: 300,
 });


### PR DESCRIPTION
This pull request fixes embedUrl matching for Vidplay and Filemoon sources

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
