### PR TITLE
Remove url logging

### DIFF
--- a/src/providers/sources/hdrezka/utils.ts
+++ b/src/providers/sources/hdrezka/utils.ts
@@ -52,7 +52,6 @@ function parseVideoLinks(inputString?: string): FileBasedStream['qualities'] {
       const numericQualityMatch = qualityText.match(/(\d+p)/);
       const quality = numericQualityMatch ? numericQualityMatch[1] : 'Unknown';
 
-      console.log(quality, mp4Url);
       const validQuality = getValidQualityFromString(quality);
       result[validQuality] = { type: 'mp4', url: mp4Url };
     }


### PR DESCRIPTION
This pull request resolves the issue where the URL is logged in the console (for the discord bot)

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] I have tested all of my changes.
