### PR TITLE
Disable sources that no longer work

### DIFF
--- a/src/providers/sources/flixhq/index.ts
+++ b/src/providers/sources/flixhq/index.ts
@@ -11,6 +11,7 @@ export const flixhqScraper = makeSourcerer({
   name: 'FlixHQ',
   rank: 100,
   flags: [flags.CORS_ALLOWED],
+  disabled: true,
   async scrapeMovie(ctx) {
     const id = await getFlixhqId(ctx, ctx.media);
     if (!id) throw new NotFoundError('no search results match');

--- a/src/providers/sources/gomovies/index.ts
+++ b/src/providers/sources/gomovies/index.ts
@@ -14,6 +14,7 @@ export const goMoviesScraper = makeSourcerer({
   name: 'GOmovies',
   rank: 110,
   flags: [flags.CORS_ALLOWED],
+  disabled: true,
   async scrapeShow(ctx) {
     const search = await ctx.proxiedFetcher<string>(`/ajax/search`, {
       method: 'POST',

--- a/src/providers/sources/goojara/index.ts
+++ b/src/providers/sources/goojara/index.ts
@@ -24,6 +24,7 @@ export const goojaraScraper = makeSourcerer({
   name: 'Goojara',
   rank: 225,
   flags: [],
+  disabled: true,
   scrapeShow: universalScraper,
   scrapeMovie: universalScraper,
 });

--- a/src/providers/sources/nepu/index.ts
+++ b/src/providers/sources/nepu/index.ts
@@ -78,6 +78,7 @@ export const nepuScraper = makeSourcerer({
   name: 'Nepu',
   rank: 111,
   flags: [],
+  disabled: true,
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,
 });

--- a/src/providers/sources/smashystream/index.ts
+++ b/src/providers/sources/smashystream/index.ts
@@ -59,6 +59,7 @@ export const smashyStreamScraper = makeSourcerer({
   name: 'SmashyStream',
   rank: 70,
   flags: [flags.CORS_ALLOWED],
+  disabled: true,
   scrapeMovie: universalScraper,
   scrapeShow: universalScraper,
 });

--- a/src/providers/sources/zoechip/index.ts
+++ b/src/providers/sources/zoechip/index.ts
@@ -8,6 +8,7 @@ export const zoechipScraper = makeSourcerer({
   name: 'ZoeChip',
   rank: 200,
   flags: [flags.CORS_ALLOWED],
+  disabled: true,
   scrapeMovie,
   scrapeShow,
 });


### PR DESCRIPTION
This pull request partially resolves [#1026](https://github.com/movie-web/movie-web/issues/1026)

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [ ] I have tested all of my changes.

Note -
I purposefully haven't disabled RidoMovies as the scraper seemingly still works, although the url does block you, It maybe works in some cases, I have no idea, if anyone wants to follow up with me on that, that'd be great.
If necessary we can disable RidoMovies, although imo we might as well just keep it as is, it seems like it could fix itself.