### PR TITLE
febbox-mp4: remove removeBadUrlParams

### DIFF
--- a/src/providers/embeds/febbox/qualities.ts
+++ b/src/providers/embeds/febbox/qualities.ts
@@ -20,21 +20,6 @@ function mapToQuality(quality: FebboxQuality): FebboxQuality | null {
   };
 }
 
-function removeBadUrlParams(url: string): string {
-  const urlObject = new URL(url);
-
-  const urlSearchParams = new URLSearchParams(urlObject.search);
-
-  const keysToKeep = ['KEY1', 'KEY2'];
-  for (const key of Array.from(urlSearchParams.keys())) {
-    if (!keysToKeep.includes(key)) {
-      urlSearchParams.delete(key);
-    }
-  }
-
-  return `${urlObject.origin}${urlObject.pathname}?${urlSearchParams.toString()}`;
-}
-
 export async function getStreamQualities(ctx: ScrapeContext, apiQuery: object) {
   const mediaRes: { list: FebboxQuality[] } = (await sendRequest(ctx, apiQuery)).data;
 
@@ -47,7 +32,7 @@ export async function getStreamQualities(ctx: ScrapeContext, apiQuery: object) {
     if (foundQuality) {
       qualities[quality] = {
         type: 'mp4',
-        url: removeBadUrlParams(foundQuality.path),
+        url: foundQuality.path,
       };
     }
   });


### PR DESCRIPTION
This pull request resolves #XXX

Febbox now requires the queries removed by removeBadUrlParams.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
