### PR TITLE
add VidSrcPro source

### DIFF
--- a/src/providers/all.ts
+++ b/src/providers/all.ts
@@ -27,6 +27,8 @@ import { streamtapeScraper } from './embeds/streamtape';
 import { streamvidScraper } from './embeds/streamvid';
 import { vidCloudScraper } from './embeds/vidcloud';
 import { vidplayScraper } from './embeds/vidplay';
+import { jettScraper } from './embeds/vidsrcpro-jett';
+import { viperScraper } from './embeds/vidsrcpro-viper';
 import { voeScraper } from './embeds/voe';
 import { wootlyScraper } from './embeds/wootly';
 import { goojaraScraper } from './sources/goojara';
@@ -35,6 +37,7 @@ import { nepuScraper } from './sources/nepu';
 import { primewireScraper } from './sources/primewire';
 import { ridooMoviesScraper } from './sources/ridomovies';
 import { smashyStreamScraper } from './sources/smashystream';
+import { vidSrcProScraper } from './sources/vidsrcpro';
 import { vidSrcToScraper } from './sources/vidsrcto';
 
 export function gatherAllSources(): Array<Sourcerer> {
@@ -51,6 +54,7 @@ export function gatherAllSources(): Array<Sourcerer> {
     smashyStreamScraper,
     ridooMoviesScraper,
     vidSrcToScraper,
+    vidSrcProScraper,
     nepuScraper,
     goojaraScraper,
     hdRezkaScraper,
@@ -82,5 +86,7 @@ export function gatherAllEmbeds(): Array<Embed> {
     streamvidScraper,
     voeScraper,
     streamtapeScraper,
+    viperScraper,
+    jettScraper,
   ];
 }

--- a/src/providers/embeds/vidsrcpro-jett.ts
+++ b/src/providers/embeds/vidsrcpro-jett.ts
@@ -1,0 +1,70 @@
+import { flags } from '@/entrypoint/utils/targets';
+
+import { makeEmbed } from '../base';
+import { Caption, getCaptionTypeFromUrl, labelToLanguageCode } from '../captions';
+
+type embedRes = {
+  source: string;
+  thumbnails?: string;
+  subtitles?: {
+    file: string;
+    label: string;
+  }[];
+};
+type ThumbnailTrack = {
+  type: 'vtt';
+  url: string;
+};
+
+export const jettScraper = makeEmbed({
+  id: 'jett',
+  name: 'VidSrcPro-jett',
+  rank: 300,
+  scrape: async (ctx) => {
+    const embedRes = await ctx.fetcher<embedRes>(ctx.url, {
+      headers: {
+        referer: ctx.url,
+      },
+    });
+
+    const captions: Caption[] = [];
+    if (embedRes.subtitles) {
+      for (const caption of embedRes.subtitles) {
+        const language = labelToLanguageCode(caption.label);
+        const captionType = getCaptionTypeFromUrl(caption.file);
+        if (!language || !captionType) continue;
+        captions.push({
+          id: caption.file,
+          url: caption.file,
+          type: captionType,
+          language,
+          hasCorsRestrictions: false,
+        });
+      }
+    }
+
+    let thumbnailTrack: ThumbnailTrack | undefined;
+    if (embedRes.thumbnails) {
+      thumbnailTrack = {
+        type: 'vtt',
+        url: embedRes.thumbnails,
+      };
+    }
+
+    return {
+      stream: [
+        {
+          id: 'primary',
+          type: 'hls',
+          playlist: embedRes.source,
+          headers: {
+            Referer: new URL(ctx.url).origin,
+          },
+          thumbnailTrack,
+          captions,
+          flags: [flags.IP_LOCKED],
+        },
+      ],
+    };
+  },
+});

--- a/src/providers/embeds/vidsrcpro-viper.ts
+++ b/src/providers/embeds/vidsrcpro-viper.ts
@@ -1,0 +1,70 @@
+import { flags } from '@/entrypoint/utils/targets';
+
+import { makeEmbed } from '../base';
+import { Caption, getCaptionTypeFromUrl, labelToLanguageCode } from '../captions';
+
+type embedRes = {
+  source: string;
+  thumbnails?: string;
+  subtitles?: {
+    file: string;
+    label: string;
+  }[];
+};
+type ThumbnailTrack = {
+  type: 'vtt';
+  url: string;
+};
+
+export const viperScraper = makeEmbed({
+  id: 'viper',
+  name: 'VidSrcPro-viper',
+  rank: 250,
+  scrape: async (ctx) => {
+    const embedRes = await ctx.fetcher<embedRes>(ctx.url, {
+      headers: {
+        referer: ctx.url,
+      },
+    });
+
+    const captions: Caption[] = [];
+    if (embedRes.subtitles) {
+      for (const caption of embedRes.subtitles) {
+        const language = labelToLanguageCode(caption.label);
+        const captionType = getCaptionTypeFromUrl(caption.file);
+        if (!language || !captionType) continue;
+        captions.push({
+          id: caption.file,
+          url: caption.file,
+          type: captionType,
+          language,
+          hasCorsRestrictions: false,
+        });
+      }
+    }
+
+    let thumbnailTrack: ThumbnailTrack | undefined;
+    if (embedRes.thumbnails) {
+      thumbnailTrack = {
+        type: 'vtt',
+        url: embedRes.thumbnails,
+      };
+    }
+
+    return {
+      stream: [
+        {
+          id: 'primary',
+          type: 'hls',
+          playlist: embedRes.source,
+          headers: {
+            Referer: new URL(ctx.url).origin,
+          },
+          thumbnailTrack,
+          captions,
+          flags: [flags.IP_LOCKED],
+        },
+      ],
+    };
+  },
+});

--- a/src/providers/sources/vidsrcpro.ts
+++ b/src/providers/sources/vidsrcpro.ts
@@ -1,0 +1,55 @@
+import { load } from 'cheerio';
+
+import { flags } from '@/entrypoint/utils/targets';
+import { SourcererEmbed, SourcererOutput, makeSourcerer } from '@/providers/base';
+import { MovieScrapeContext, ShowScrapeContext } from '@/utils/context';
+
+type hashResult = {
+  name: 'jett' | 'viper';
+  hash: string;
+};
+
+const vidSrcProBase = 'https://vidsrc.pro';
+const referer = `${vidSrcProBase}/`;
+
+const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Promise<SourcererOutput> => {
+  const hashRegex = /"hash":\s*"([^"]+)"/;
+  const tmdbId = ctx.media.tmdbId;
+
+  const url =
+    ctx.media.type === 'movie'
+      ? `/embed/movie/${tmdbId}`
+      : `/embed/tv/${tmdbId}/${ctx.media.season.number}/${ctx.media.episode.number}`;
+
+  const mainPage = await ctx.fetcher<string>(url, {
+    baseUrl: vidSrcProBase,
+    headers: {
+      referer,
+    },
+  });
+  const mainPage$ = load(mainPage);
+  const hash = mainPage$('script').text().match(hashRegex);
+  if (!hash) throw new Error('No hash found');
+  const decodedHash: hashResult[] = JSON.parse(atob(hash[1].split('').reverse().join('')));
+
+  const embeds: SourcererEmbed[] = [];
+  for (const source of decodedHash) {
+    embeds.push({
+      embedId: source.name,
+      url: `${vidSrcProBase}/api/e/${source.hash}`,
+    });
+  }
+
+  return {
+    embeds,
+  };
+};
+
+export const vidSrcProScraper = makeSourcerer({
+  id: 'vidsrcpro',
+  name: 'VidSrcPro',
+  scrapeMovie: universalScraper,
+  scrapeShow: universalScraper,
+  flags: [flags.CORS_ALLOWED, flags.IP_LOCKED],
+  rank: 115,
+});


### PR DESCRIPTION
This pull request adds the source vidsrc.pro and two of its embeds, jett and viper.
It has subtitles and good 1080p HLS streams. This is for extension users, since the streams are ip-locked

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
