### PR TITLE
Validate if a stream is actually playable

### DIFF
--- a/src/runners/runner.ts
+++ b/src/runners/runner.ts
@@ -8,7 +8,7 @@ import { Stream } from '@/providers/streams';
 import { ScrapeContext } from '@/utils/context';
 import { NotFoundError } from '@/utils/errors';
 import { reorderOnIdList } from '@/utils/list';
-import { isValidStream } from '@/utils/valid';
+import { isValidStream, validatePlayableStream } from '@/utils/valid';
 
 export type RunOutput = {
   sourceId: string;
@@ -104,9 +104,11 @@ export async function runAllProviders(list: ProviderList, ops: ProviderRunnerOpt
 
     // return stream is there are any
     if (output.stream?.[0]) {
+      const playableStream = await validatePlayableStream(output.stream[0], ops);
+      if (!playableStream) throw new NotFoundError('No streams found');
       return {
         sourceId: source.id,
-        stream: output.stream[0],
+        stream: playableStream,
       };
     }
 
@@ -161,11 +163,13 @@ export async function runAllProviders(list: ProviderList, ops: ProviderRunnerOpt
         ops.events?.update?.(updateParams);
         continue;
       }
+      const playableStream = await validatePlayableStream(embedOutput.stream[0], ops);
+      if (!playableStream) throw new NotFoundError('No streams found');
 
       return {
         sourceId: source.id,
         embedId: scraper.id,
-        stream: embedOutput.stream[0],
+        stream: playableStream,
       };
     }
   }

--- a/src/runners/runner.ts
+++ b/src/runners/runner.ts
@@ -151,6 +151,9 @@ export async function runAllProviders(list: ProviderList, ops: ProviderRunnerOpt
         if (embedOutput.stream.length === 0) {
           throw new NotFoundError('No streams found');
         }
+        const playableStream = await validatePlayableStream(embedOutput.stream[0], ops);
+        if (!playableStream) throw new NotFoundError('No streams found');
+        embedOutput.stream = [playableStream];
       } catch (error) {
         const updateParams: UpdateEvent = {
           id: source.id,
@@ -163,13 +166,11 @@ export async function runAllProviders(list: ProviderList, ops: ProviderRunnerOpt
         ops.events?.update?.(updateParams);
         continue;
       }
-      const playableStream = await validatePlayableStream(embedOutput.stream[0], ops);
-      if (!playableStream) throw new NotFoundError('No streams found');
 
       return {
         sourceId: source.id,
         embedId: scraper.id,
-        stream: playableStream,
+        stream: embedOutput.stream[0],
       };
     }
   }

--- a/src/utils/valid.ts
+++ b/src/utils/valid.ts
@@ -1,4 +1,6 @@
 import { Stream } from '@/providers/streams';
+import { IndividualEmbedRunnerOptions } from '@/runners/individualRunner';
+import { ProviderRunnerOptions } from '@/runners/runner';
 
 export function isValidStream(stream: Stream | undefined): boolean {
   if (!stream) return false;
@@ -14,4 +16,55 @@ export function isValidStream(stream: Stream | undefined): boolean {
 
   // unknown file type
   return false;
+}
+
+export async function validatePlayableStream(
+  stream: Stream,
+  ops: ProviderRunnerOptions | IndividualEmbedRunnerOptions,
+): Promise<Stream | null> {
+  const fetcher = stream.flags.includes('cors-allowed') ? ops.fetcher : ops.proxiedFetcher;
+  if (stream.type === 'hls') {
+    const headResult = await fetcher.full(stream.playlist, {
+      method: 'HEAD',
+      headers: {
+        ...stream.preferredHeaders,
+        ...stream.headers,
+      },
+    });
+    if (headResult.statusCode !== 200) return null;
+    return stream;
+  }
+  if (stream.type === 'file') {
+    const validQualitiesResults = await Promise.all(
+      Object.values(stream.qualities).map((quality) =>
+        fetcher.full(quality.url, {
+          method: 'HEAD',
+          headers: {
+            ...stream.preferredHeaders,
+            ...stream.headers,
+          },
+        }),
+      ),
+    );
+    // remove invalid qualities from the stream
+    const validQualities = stream.qualities;
+    Object.keys(stream.qualities).forEach((quality, index) => {
+      if (validQualitiesResults[index].statusCode !== 200) {
+        delete validQualities[quality as keyof typeof stream.qualities];
+      }
+    });
+
+    if (Object.keys(validQualities).length === 0) return null;
+    return { ...stream, qualities: validQualities };
+  }
+  return null;
+}
+
+export async function validatePlayableStreams(
+  streams: Stream[],
+  ops: ProviderRunnerOptions | IndividualEmbedRunnerOptions,
+): Promise<Stream[]> {
+  return (await Promise.all(streams.map((stream) => validatePlayableStream(stream, ops)))).filter(
+    (v) => v !== null,
+  ) as Stream[];
 }

--- a/src/utils/valid.ts
+++ b/src/utils/valid.ts
@@ -22,7 +22,7 @@ export async function validatePlayableStream(
   stream: Stream,
   ops: ProviderRunnerOptions | IndividualEmbedRunnerOptions,
 ): Promise<Stream | null> {
-  const fetcher = stream.flags.includes('cors-allowed') ? ops.fetcher : ops.proxiedFetcher;
+  const fetcher = stream.flags.length === 1 && stream.flags.includes('cors-allowed') ? ops.fetcher : ops.proxiedFetcher;
   if (stream.type === 'hls') {
     const headResult = await fetcher.full(stream.playlist, {
       method: 'HEAD',


### PR DESCRIPTION
We have encountered issues in our frontend because the providers library returns url's that are not valid. For example they return a 403 because of missing parameters in the URL. If a stream is not valid, it should not be returned by the providers library. With this implementation we validate if the URL is valid by sending a HEAD request before actually returning it. Now we also do not have to do this individually for each provider, since it is checked after the scrape.

Will do a bit more testing, but seems to work well

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
