### PR TITLE
Fix showbox

### DIFF
--- a/src/utils/valid.ts
+++ b/src/utils/valid.ts
@@ -30,7 +30,7 @@ export async function validatePlayableStream(
         ...stream.headers,
       },
     });
-    if (result.statusCode !== 200) return null;
+    if (result.statusCode < 200 || result.statusCode >= 400) return null;
     return stream;
   }
   if (stream.type === 'file') {


### PR DESCRIPTION
Lets try and fix it again shall we. Showbox does not accept HEAD requests on their mp4 files. It also CORS blocks it because of the Origin header that is passed in for regular requests, returning a "default_origin.com". So it needs to be proxied. We now request the first byte of the video file to see it resolve (see screenshot)

![image](https://github.com/movie-web/providers/assets/43169049/8ecb4f89-196b-4c2c-b9bf-24c21974a182)


 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
