### PR TITLE
Embeds

### DIFF
--- a/src/providers/all.ts
+++ b/src/providers/all.ts
@@ -1,7 +1,9 @@
 import { Embed, Sourcerer } from '@/providers/base';
 import { doodScraper } from '@/providers/embeds/dood';
+import { droploadScraper } from '@/providers/embeds/dropload';
 import { febboxHlsScraper } from '@/providers/embeds/febbox/hls';
 import { febboxMp4Scraper } from '@/providers/embeds/febbox/mp4';
+import { filelionsScraper } from '@/providers/embeds/filelions';
 import { mixdropScraper } from '@/providers/embeds/mixdrop';
 import { mp4uploadScraper } from '@/providers/embeds/mp4upload';
 import { streambucketScraper } from '@/providers/embeds/streambucket';
@@ -9,6 +11,7 @@ import { streamsbScraper } from '@/providers/embeds/streamsb';
 import { upcloudScraper } from '@/providers/embeds/upcloud';
 import { upstreamScraper } from '@/providers/embeds/upstream';
 import { vidsrcembedScraper } from '@/providers/embeds/vidsrc';
+import { vTubeScraper } from '@/providers/embeds/vtube';
 import { flixhqScraper } from '@/providers/sources/flixhq/index';
 import { goMoviesScraper } from '@/providers/sources/gomovies/index';
 import { kissAsianScraper } from '@/providers/sources/kissasian/index';
@@ -82,5 +85,8 @@ export function gatherAllEmbeds(): Array<Embed> {
     streamvidScraper,
     voeScraper,
     streamtapeScraper,
+    droploadScraper,
+    filelionsScraper,
+    vTubeScraper,
   ];
 }

--- a/src/providers/embeds/dood.ts
+++ b/src/providers/embeds/dood.ts
@@ -25,6 +25,7 @@ export const doodScraper = makeEmbed({
 
     const dataForLater = doodData.match(/\?token=([^&]+)&expiry=/)?.[1];
     const path = doodData.match(/\$\.get\('\/pass_md5([^']+)/)?.[1];
+    const thumbnailTrack = doodData.match(/thumbnails:\s\{\s*vtt:\s'([^']*)'/);
 
     const doodPage = await ctx.proxiedFetcher<string>(`/pass_md5${path}`, {
       headers: {
@@ -53,6 +54,14 @@ export const doodScraper = makeEmbed({
           headers: {
             Referer: baseUrl,
           },
+          ...(thumbnailTrack
+            ? {
+                thumbnailTrack: {
+                  type: 'vtt',
+                  url: `https:${thumbnailTrack[1]}`,
+                },
+              }
+            : {}),
         },
       ],
     };

--- a/src/providers/embeds/dropload.ts
+++ b/src/providers/embeds/dropload.ts
@@ -1,0 +1,56 @@
+import { unpack } from 'unpacker';
+
+import { flags } from '@/entrypoint/utils/targets';
+
+import { makeEmbed } from '../base';
+
+const evalCodeRegex = /eval\((.*)\)/g;
+const fileRegex = /file:"(.*?)"/g;
+const tracksRegex = /\{file:"([^"]+)",kind:"thumbnails"\}/g;
+
+export const droploadScraper = makeEmbed({
+  id: 'dropload',
+  name: 'Dropload',
+  rank: 120,
+  scrape: async (ctx) => {
+    const mainPageRes = await ctx.fetcher.full<string>(ctx.url, {
+      headers: {
+        referer: ctx.url,
+      },
+    });
+    const mainPageUrl = new URL(mainPageRes.finalUrl);
+    const mainPage = mainPageRes.body;
+
+    const evalCode = mainPage.match(evalCodeRegex);
+    if (!evalCode) throw new Error('Failed to find eval code');
+    const unpacked = unpack(evalCode[1]);
+
+    const file = fileRegex.exec(unpacked);
+    const thumbnailTrack = tracksRegex.exec(unpacked);
+    if (!file?.[1]) throw new Error('Failed to find file');
+
+    return {
+      stream: [
+        {
+          id: 'primary',
+          type: 'hls',
+          playlist: file[1],
+          flags: [flags.IP_LOCKED, flags.CORS_ALLOWED],
+          captions: [],
+          preferredHeaders: {
+            Referer: mainPageUrl.origin,
+            origin: mainPageUrl.origin,
+          },
+          ...(thumbnailTrack
+            ? {
+                thumbnailTrack: {
+                  type: 'vtt',
+                  url: mainPageUrl.origin + thumbnailTrack[1],
+                },
+              }
+            : {}),
+        },
+      ],
+    };
+  },
+});

--- a/src/providers/embeds/dropload.ts
+++ b/src/providers/embeds/dropload.ts
@@ -13,7 +13,7 @@ export const droploadScraper = makeEmbed({
   name: 'Dropload',
   rank: 120,
   scrape: async (ctx) => {
-    const mainPageRes = await ctx.fetcher.full<string>(ctx.url, {
+    const mainPageRes = await ctx.proxiedFetcher.full<string>(ctx.url, {
       headers: {
         referer: ctx.url,
       },
@@ -37,10 +37,6 @@ export const droploadScraper = makeEmbed({
           playlist: file[1],
           flags: [flags.IP_LOCKED, flags.CORS_ALLOWED],
           captions: [],
-          preferredHeaders: {
-            Referer: mainPageUrl.origin,
-            origin: mainPageUrl.origin,
-          },
           ...(thumbnailTrack
             ? {
                 thumbnailTrack: {

--- a/src/providers/embeds/filelions.ts
+++ b/src/providers/embeds/filelions.ts
@@ -10,7 +10,7 @@ export const filelionsScraper = makeEmbed({
   name: 'filelions',
   rank: 115,
   async scrape(ctx) {
-    const mainPageRes = await ctx.fetcher.full<string>(ctx.url, {
+    const mainPageRes = await ctx.proxiedFetcher.full<string>(ctx.url, {
       headers: {
         referer: ctx.url,
       },
@@ -32,15 +32,11 @@ export const filelionsScraper = makeEmbed({
           playlist,
           flags: [flags.IP_LOCKED, flags.CORS_ALLOWED],
           captions: [],
-          preferredHeaders: {
-            Referer: mainPageUrl.origin,
-            origin: mainPageUrl.origin,
-          },
           ...(thumbnailTrack
             ? {
                 thumbnailTrack: {
                   type: 'vtt',
-                  url: new URL(mainPageRes.finalUrl).origin + thumbnailTrack[1],
+                  url: mainPageUrl.origin + thumbnailTrack[1],
                 },
               }
             : {}),

--- a/src/providers/embeds/filelions.ts
+++ b/src/providers/embeds/filelions.ts
@@ -1,0 +1,51 @@
+import { flags } from '@/entrypoint/utils/targets';
+import { makeEmbed } from '@/providers/base';
+
+const linkRegex = /file: ?"(http.*?)"/;
+// the white space charecters may seem useless, but without them it breaks
+const tracksRegex = /\{file:\s"([^"]+)",\skind:\s"thumbnails"\}/g;
+
+export const filelionsScraper = makeEmbed({
+  id: 'filelions',
+  name: 'filelions',
+  rank: 115,
+  async scrape(ctx) {
+    const mainPageRes = await ctx.fetcher.full<string>(ctx.url, {
+      headers: {
+        referer: ctx.url,
+      },
+    });
+    const mainPage = mainPageRes.body;
+    const mainPageUrl = new URL(mainPageRes.finalUrl);
+
+    const streamUrl = mainPage.match(linkRegex) ?? [];
+    const thumbnailTrack = tracksRegex.exec(mainPage);
+
+    const playlist = streamUrl[1];
+    if (!playlist) throw new Error('Stream url not found');
+
+    return {
+      stream: [
+        {
+          id: 'primary',
+          type: 'hls',
+          playlist,
+          flags: [flags.IP_LOCKED, flags.CORS_ALLOWED],
+          captions: [],
+          preferredHeaders: {
+            Referer: mainPageUrl.origin,
+            origin: mainPageUrl.origin,
+          },
+          ...(thumbnailTrack
+            ? {
+                thumbnailTrack: {
+                  type: 'vtt',
+                  url: new URL(mainPageRes.finalUrl).origin + thumbnailTrack[1],
+                },
+              }
+            : {}),
+        },
+      ],
+    };
+  },
+});

--- a/src/providers/embeds/mixdrop.ts
+++ b/src/providers/embeds/mixdrop.ts
@@ -1,5 +1,6 @@
 import * as unpacker from 'unpacker';
 
+import { flags } from '@/entrypoint/utils/targets';
 import { makeEmbed } from '@/providers/base';
 
 const mixdropBase = 'https://mixdrop.ag';
@@ -47,7 +48,7 @@ export const mixdropScraper = makeEmbed({
         {
           id: 'primary',
           type: 'file',
-          flags: [],
+          flags: [flags.IP_LOCKED],
           captions: [],
           qualities: {
             unknown: {

--- a/src/providers/embeds/voe.ts
+++ b/src/providers/embeds/voe.ts
@@ -2,15 +2,18 @@ import { flags } from '@/entrypoint/utils/targets';
 import { makeEmbed } from '@/providers/base';
 
 const linkRegex = /'hls': ?'(http.*?)',/;
+const tracksRegex = /previewThumbnails:\s{.*src:\["([^"]+)"]/;
 
 export const voeScraper = makeEmbed({
   id: 'voe',
   name: 'voe.sx',
   rank: 180,
   async scrape(ctx) {
-    const embed = await ctx.proxiedFetcher<string>(ctx.url);
+    const embedRes = await ctx.proxiedFetcher.full<string>(ctx.url);
+    const embed = embedRes.body;
 
     const playerSrc = embed.match(linkRegex) ?? [];
+    const thumbnailTrack = embed.match(tracksRegex);
 
     const streamUrl = playerSrc[1];
     if (!streamUrl) throw new Error('Stream url not found in embed code');
@@ -21,11 +24,19 @@ export const voeScraper = makeEmbed({
           type: 'hls',
           id: 'primary',
           playlist: streamUrl,
-          flags: [flags.CORS_ALLOWED],
+          flags: [flags.CORS_ALLOWED, flags.IP_LOCKED],
           captions: [],
           headers: {
             Referer: 'https://voe.sx',
           },
+          ...(thumbnailTrack
+            ? {
+                thumbnailTrack: {
+                  type: 'vtt',
+                  url: new URL(embedRes.finalUrl).origin + thumbnailTrack[1],
+                },
+              }
+            : {}),
         },
       ],
     };

--- a/src/providers/embeds/vtube.ts
+++ b/src/providers/embeds/vtube.ts
@@ -14,7 +14,7 @@ export const vTubeScraper = makeEmbed({
   name: 'vTube',
   rank: 145,
   scrape: async (ctx) => {
-    const mainPageRes = await ctx.fetcher.full<string>(ctx.url, {
+    const mainPageRes = await ctx.proxiedFetcher.full<string>(ctx.url, {
       headers: {
         referer: ctx.url,
       },

--- a/src/providers/embeds/vtube.ts
+++ b/src/providers/embeds/vtube.ts
@@ -1,0 +1,51 @@
+import { load } from 'cheerio';
+import { unpack } from 'unpacker';
+
+import { flags } from '@/entrypoint/utils/targets';
+
+import { makeEmbed } from '../base';
+
+const evalCodeRegex = /eval\((.*)\)/g;
+const fileRegex = /file:"(.*?)"/g;
+const tracksRegex = /\{file:"([^"]+)",kind:"thumbnails"\}/g;
+
+export const vTubeScraper = makeEmbed({
+  id: 'vtube',
+  name: 'vTube',
+  rank: 145,
+  scrape: async (ctx) => {
+    const mainPageRes = await ctx.fetcher.full<string>(ctx.url, {
+      headers: {
+        referer: ctx.url,
+      },
+    });
+    const mainPage = mainPageRes.body;
+    const html = load(mainPage);
+    const evalCode = html('script').text().match(evalCodeRegex);
+    if (!evalCode) throw new Error('Failed to find eval code');
+    const unpacked = unpack(evalCode?.toString());
+    const file = fileRegex.exec(unpacked);
+    const thumbnailTrack = tracksRegex.exec(unpacked);
+    if (!file?.[1]) throw new Error('Failed to find file');
+
+    return {
+      stream: [
+        {
+          id: 'primary',
+          type: 'hls',
+          playlist: file[1],
+          flags: [flags.CORS_ALLOWED],
+          captions: [],
+          ...(thumbnailTrack
+            ? {
+                thumbnailTrack: {
+                  type: 'vtt',
+                  url: new URL(mainPageRes.finalUrl).origin + thumbnailTrack[1],
+                },
+              }
+            : {}),
+        },
+      ],
+    };
+  },
+});

--- a/src/providers/sources/primewire/index.ts
+++ b/src/providers/sources/primewire/index.ts
@@ -54,6 +54,15 @@ async function getStreams(title: string) {
         case 'dood.watch':
           embedId = 'dood';
           break;
+        case 'dropload.io':
+          embedId = 'dropload';
+          break;
+        case 'filelions.to':
+          embedId = 'filelions';
+          break;
+        case 'vtube.to':
+          embedId = 'vtube';
+          break;
         default:
           embedId = null;
       }


### PR DESCRIPTION
Added filelions, dropload and vtube embeds for primewire
Added ip-locked flag to mixdrop
Use thumbnailTracks from dood and voe

For testing,
TMDB 618588 and 823464 on primewire include all the embeds that have been modified or added.

Closes movie-web/movie-web#1069

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
