### PR TITLE
filter out duplicate embeds

### DIFF
--- a/src/providers/embeds/filemoon/index.ts
+++ b/src/providers/embeds/filemoon/index.ts
@@ -1,8 +1,6 @@
 import { load } from 'cheerio';
 import { unpack } from 'unpacker';
 
-import { flags } from '@/entrypoint/utils/targets';
-
 import { SubtitleResult } from './types';
 import { makeEmbed } from '../../base';
 import { Caption, getCaptionTypeFromUrl, labelToLanguageCode } from '../../captions';

--- a/src/runners/individualRunner.ts
+++ b/src/runners/individualRunner.ts
@@ -59,12 +59,14 @@ export async function scrapeInvidualSource(
 
   if (!output) throw new Error('output is null');
 
-  // filter output with only valid embeds that are not disabled
-  output.embeds = output.embeds.filter((embed) => {
-    const e = list.embeds.find((v) => v.id === embed.embedId);
-    if (!e || e.disabled) return false;
-    return true;
-  });
+  // filter output with only valid embeds that are not disabled, and remove duplicates
+  output.embeds = output.embeds
+    .filter((embed) => {
+      const e = list.embeds.find((v) => v.id === embed.embedId);
+      if (!e || e.disabled) return false;
+      return true;
+    })
+    .filter((v, i, a) => a.findIndex((t) => t.embedId === v.embedId) === i);
 
   if ((!output.stream || output.stream.length === 0) && output.embeds.length === 0)
     throw new NotFoundError('No streams found');

--- a/src/runners/runner.ts
+++ b/src/runners/runner.ts
@@ -112,12 +112,13 @@ export async function runAllProviders(list: ProviderList, ops: ProviderRunnerOpt
       };
     }
 
-    // filter disabled and run embed scrapers on listed embeds
+    // filter disabled, filter out duplicates, run embed scrapers on listed embeds
     const sortedEmbeds = output.embeds
       .filter((embed) => {
         const e = list.embeds.find((v) => v.id === embed.embedId);
         return e && !e.disabled;
       })
+      .filter((v, i, a) => a.findIndex((t) => t.embedId === v.embedId) === i)
       .sort((a, b) => embedIds.indexOf(a.embedId) - embedIds.indexOf(b.embedId));
 
     if (sortedEmbeds.length > 0) {


### PR DESCRIPTION
Multiple embeds of the same site do not really make much sense, because the quality and speed in most cases is the same. We should filter them out to avoid confusion.

From
![image](https://github.com/movie-web/providers/assets/43169049/337002e6-9059-4741-b729-1c0024d4513e)

To
![image](https://github.com/movie-web/providers/assets/43169049/a049015d-81a0-47c4-99b9-e3ed41efa031)


 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
