### PR TITLE
fix ridomovies search

### DIFF
--- a/src/providers/sources/ridomovies/index.ts
+++ b/src/providers/sources/ridomovies/index.ts
@@ -19,13 +19,19 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
       q: ctx.media.title,
     },
   });
-  const show = searchResult.data.items[0];
-  if (!show) throw new NotFoundError('No watchable item found');
+  const mediaData = searchResult.data.items.map((movieEl) => {
+    const name = movieEl.title;
+    const year = movieEl.contentable.releaseYear;
+    const fullSlug = movieEl.fullSlug;
+    return { name, year, fullSlug };
+  });
+  const targetMedia = mediaData.find((m) => m.name === ctx.media.title);
+  if (!targetMedia?.fullSlug) throw new NotFoundError('No watchable item found');
 
-  let iframeSourceUrl = `/${show.fullSlug}/videos`;
+  let iframeSourceUrl = `/${targetMedia.fullSlug}/videos`;
 
   if (ctx.media.type === 'show') {
-    const showPageResult = await ctx.proxiedFetcher<string>(`/${show.fullSlug}`, {
+    const showPageResult = await ctx.proxiedFetcher<string>(`/${targetMedia.fullSlug}`, {
       baseUrl: ridoMoviesBase,
     });
     const fullEpisodeSlug = `season-${ctx.media.season.number}/episode-${ctx.media.episode.number}`;

--- a/src/providers/sources/ridomovies/index.ts
+++ b/src/providers/sources/ridomovies/index.ts
@@ -25,7 +25,7 @@ const universalScraper = async (ctx: MovieScrapeContext | ShowScrapeContext) => 
     const fullSlug = movieEl.fullSlug;
     return { name, year, fullSlug };
   });
-  const targetMedia = mediaData.find((m) => m.name === ctx.media.title);
+  const targetMedia = mediaData.find((m) => m.name === ctx.media.title && m.year === ctx.media.releaseYear.toString());
   if (!targetMedia?.fullSlug) throw new NotFoundError('No watchable item found');
 
   let iframeSourceUrl = `/${targetMedia.fullSlug}/videos`;


### PR DESCRIPTION
This pull request fixes ridomovies returning wrong media. Now it doesn't take the first result, it checks all the results for the title and releaseYear. 

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
