### PR TITLE
Vidsrc.me

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-  "eslint.format.enable": true
+  "eslint.format.enable": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,5 @@
 {
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-  "eslint.format.enable": true,
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  }
+  "eslint.format.enable": true
 }

--- a/src/providers/embeds/vidsrc.ts
+++ b/src/providers/embeds/vidsrc.ts
@@ -32,20 +32,23 @@ export const vidsrcembedScraper = makeEmbed({
     if (!finalUrl.includes('.m3u8')) throw new Error('Unable to find HLS playlist');
 
     let setPassLink = html.match(setPassRegex)?.[1];
-    if (!setPassLink) throw new Error('Unable to find set_pass.php link');
 
-    if (setPassLink.startsWith('//')) {
-      setPassLink = `https:${setPassLink}`;
+    // isn't neeeded, the stream works without it anyway
+    // shouldn't fail if the setpass link is not found
+    if (setPassLink) {
+      if (setPassLink.startsWith('//')) {
+        setPassLink = `https:${setPassLink}`;
+      }
+
+      // VidSrc uses a password endpoint to temporarily whitelist the user's IP. This is called in an interval by the player.
+      // It currently has no effect on the player itself, the content plays fine without it.
+      // In the future we might have to introduce hooks for the frontend to call this endpoint.
+      await ctx.proxiedFetcher(setPassLink, {
+        headers: {
+          referer: ctx.url,
+        },
+      });
     }
-
-    // VidSrc uses a password endpoint to temporarily whitelist the user's IP. This is called in an interval by the player.
-    // It currently has no effect on the player itself, the content plays fine without it.
-    // In the future we might have to introduce hooks for the frontend to call this endpoint.
-    await ctx.proxiedFetcher(setPassLink, {
-      headers: {
-        referer: ctx.url,
-      },
-    });
 
     return {
       stream: [


### PR DESCRIPTION
VidSrc PRO has some sort of password endpoint to temporarily whitelist the user's IP, but the stream works without this. Seems useless so far. Previously it used to fail if the link for this endpoint wasn't found even when the stream was found. This PR changes it to only call the endpoint if the link for it is found. If the endpoind link isn't found it still returns the stream, which plays normally.

Half the time vidsrc fails because it didn't find the password endpoint link

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
