### PR TITLE
Add support for Filemoon MP4 streams

### DIFF
--- a/src/providers/all.ts
+++ b/src/providers/all.ts
@@ -26,6 +26,7 @@ import { zoechipScraper } from '@/providers/sources/zoechip';
 import { bflixScraper } from './embeds/bflix';
 import { closeLoadScraper } from './embeds/closeload';
 import { fileMoonScraper } from './embeds/filemoon';
+import { fileMoonMp4Scraper } from './embeds/filemoon/mp4';
 import { ridooScraper } from './embeds/ridoo';
 import { smashyStreamOScraper } from './embeds/smashystream/opstream';
 import { smashyStreamFScraper } from './embeds/smashystream/video1';
@@ -92,6 +93,7 @@ export function gatherAllEmbeds(): Array<Embed> {
     ridooScraper,
     closeLoadScraper,
     fileMoonScraper,
+    fileMoonMp4Scraper,
     vidplayScraper,
     wootlyScraper,
     doodScraper,

--- a/src/providers/embeds/filemoon/index.ts
+++ b/src/providers/embeds/filemoon/index.ts
@@ -11,7 +11,7 @@ const fileRegex = /file:"(.*?)"/g;
 export const fileMoonScraper = makeEmbed({
   id: 'filemoon',
   name: 'Filemoon',
-  rank: 400,
+  rank: 300,
   scrape: async (ctx) => {
     const embedRes = await ctx.proxiedFetcher<string>(ctx.url, {
       headers: {

--- a/src/providers/embeds/filemoon/mp4.ts
+++ b/src/providers/embeds/filemoon/mp4.ts
@@ -7,7 +7,7 @@ import { fileMoonScraper } from './index';
 export const fileMoonMp4Scraper = makeEmbed({
   id: 'filemoon-mp4',
   name: 'Filemoon MP4',
-  rank: 500,
+  rank: 400,
   scrape: async (ctx) => {
     const result = await fileMoonScraper.scrape(ctx);
 

--- a/src/providers/embeds/filemoon/mp4.ts
+++ b/src/providers/embeds/filemoon/mp4.ts
@@ -1,0 +1,37 @@
+import { NotFoundError } from '@/utils/errors';
+
+import { makeEmbed } from '../../base';
+
+import { fileMoonScraper } from './index';
+
+export const fileMoonMp4Scraper = makeEmbed({
+  id: 'filemoon-mp4',
+  name: 'Filemoon MP4',
+  rank: 500,
+  scrape: async (ctx) => {
+    const result = await fileMoonScraper.scrape(ctx);
+
+    if (!result.stream) throw new NotFoundError('Failed to find result');
+
+    if (result.stream[0].type !== 'hls') throw new NotFoundError('Failed to find hls stream');
+
+    const url = result.stream[0].playlist.replace(/\/hls2\//, '/download/').replace(/\.m3u8/, '.mp4');
+
+    return {
+      stream: [
+        {
+          id: 'primary',
+          type: 'file',
+          qualities: {
+            unknown: {
+              type: 'mp4',
+              url,
+            },
+          },
+          flags: [],
+          captions: result.stream[0].captions,
+        },
+      ],
+    };
+  },
+});

--- a/src/providers/sources/vidsrcto/index.ts
+++ b/src/providers/sources/vidsrcto/index.ts
@@ -60,10 +60,16 @@ const universalScraper = async (ctx: ShowScrapeContext | MovieScrapeContext): Pr
       const urlWithSubtitles = embedArr.find((v) => v.source === 'Vidplay' && v.url.includes('sub.info'))?.url;
       const subtitleUrl = urlWithSubtitles ? new URL(urlWithSubtitles).searchParams.get('sub.info') : null;
       if (subtitleUrl) fullUrl.searchParams.set('sub.info', subtitleUrl);
-      embeds.push({
-        embedId: 'filemoon',
-        url: fullUrl.toString(),
-      });
+      embeds.push(
+        {
+          embedId: 'filemoon',
+          url: fullUrl.toString(),
+        },
+        {
+          embedId: 'filemoon-mp4',
+          url: fullUrl.toString(),
+        },
+      );
     }
   }
 


### PR DESCRIPTION
This pull request adds support for Filemoon MP4 streams. All credit goes to Joost <@153779031295131648> on discord for showing me how to fetch the MP4 streams. 

Edit: @Ciarands <@1162435371683029122> found the exploit that makes this possible. Big thanks to him!

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
